### PR TITLE
Added an attenpt of binding for node and edges types

### DIFF
--- a/src/Repo/IRepo.fs
+++ b/src/Repo/IRepo.fs
@@ -4,6 +4,7 @@
 /// the contents of the repository by adding new nodes or edges as instances of some already existing elements.
 type IRepo =
     interface
+        abstract Models : unit -> string seq
         abstract ModelNodes : modelName : string -> NodeInfo seq
         abstract ModelEdges : modelName : string -> EdgeInfo seq
         abstract MetamodelNodes : modelName : string -> NodeInfo seq

--- a/src/Repo/RepoImpl.fs
+++ b/src/Repo/RepoImpl.fs
@@ -31,6 +31,9 @@ type internal RepoImpl (loader : IModelLoader) as this =
         RepoImpl(GraphMetametamodel ())
 
     interface IRepo with
+        member this.Models () = 
+            repoGraph.Keys :> seq<string>
+
         member this.ModelNodes modelName = 
             let metaclass x = if classes.ContainsKey(x) 
                               then 

--- a/tests/Repo.Tests/RepoTests.fs
+++ b/tests/Repo.Tests/RepoTests.fs
@@ -29,3 +29,6 @@ let ``Repo shall return some model nodes`` () =
 let ``Repo shall contain at least ModelElement`` () =
     (repo :> IRepo).ModelNodes modelName |> Seq.filter (fun x -> x.name = "ModelElement") |> should not' (be Empty)
 
+[<Test>]
+let ``Repo shall contain at least one model`` () =
+    (repo :> IRepo).Models () |> should not' (be Empty)


### PR DESCRIPTION
Сейчас привязка работает, но элементы отображаются некорректно (не преобразовываются к строке), и я не могу понять почему.Если обращаться к ним отдельно (var d = info.GetEdges().ToList(); var b = b[0].ToString()) то всё верно, а вот из select'a - нет. А ещё я совсем не уверена в том, что привязка выполнено красиво (выглядит очень дико), но я такой способ от человека, работающего с wpf получила, да и она работала. Если есть способ сделать элегантнее, то я бы переделала.